### PR TITLE
Minor namespace and code style cleanup

### DIFF
--- a/src/DeloitteDigital.Atlas/Constants.cs
+++ b/src/DeloitteDigital.Atlas/Constants.cs
@@ -1,4 +1,4 @@
-﻿namespace DD.Atlas
+﻿namespace DeloitteDigital.Atlas
 {
     public static class Constants
     {

--- a/src/DeloitteDigital.Atlas/Extensions/ItemExtensions.cs
+++ b/src/DeloitteDigital.Atlas/Extensions/ItemExtensions.cs
@@ -16,7 +16,7 @@ namespace DeloitteDigital.Atlas.Extensions
 {
    
     /// <summary>
-    /// Provides extention methods on the Sitecore.Data.Items.Item type
+    /// Provides extension methods on the Sitecore.Data.Items.Item type
     /// </summary>
     public static class ItemExtensions
     {
@@ -37,15 +37,15 @@ namespace DeloitteDigital.Atlas.Extensions
                 fieldRenderer.FieldName = fieldName;
                 if (attributes != null)
                 {
-                    fieldRenderer.Parameters = String.Join("&",
-                        attributes.Keys.Select(k => String.Format("{0}={1}", k, attributes[k])));
+                    fieldRenderer.Parameters = string.Join("&",
+                        attributes.Keys.Select(k => string.Format("{0}={1}", k, attributes[k])));
                 }
                 return fieldRenderer.Render();
             }
             else
             {
                 var field = item.Fields[fieldName];
-                return field != null ? field.Value : String.Empty;
+                return field != null ? field.Value : string.Empty;
             }
         }
 
@@ -74,16 +74,16 @@ namespace DeloitteDigital.Atlas.Extensions
 
         public static string GetItemUrl(this Item item, string siteName = "", string hostName = "")
         {
-            if (String.IsNullOrEmpty(siteName))
+            if (string.IsNullOrEmpty(siteName))
             {
                 return LinkManager.GetItemUrl(item);
             }
             else
             {
-                var itemUrl = String.Empty;
+                var itemUrl = string.Empty;
                 var originalSiteName = Context.Site.Name;
                 Context.SetActiveSite(siteName);
-                itemUrl = String.Format("//{0}{1}", hostName, LinkManager.GetItemUrl(item));
+                itemUrl = string.Format("//{0}{1}", hostName, LinkManager.GetItemUrl(item));
                 Context.SetActiveSite(originalSiteName);
                 return itemUrl;
             }
@@ -97,7 +97,7 @@ namespace DeloitteDigital.Atlas.Extensions
 
         public static string GetFieldValueAsDateTime(this Item item, string fieldName, string format = "")
         {
-            if (String.IsNullOrEmpty(format))
+            if (string.IsNullOrEmpty(format))
             {
                 format = "dd MMM yyyy";
             }
@@ -120,7 +120,7 @@ namespace DeloitteDigital.Atlas.Extensions
             }
             else
             {
-                return String.Empty;
+                return string.Empty;
             }
         }
 
@@ -139,7 +139,7 @@ namespace DeloitteDigital.Atlas.Extensions
                 }
             }
 
-            return String.Empty;
+            return string.Empty;
         }
 
         public static Item GetLinkFieldItem(this Item item, string fieldName)

--- a/src/DeloitteDigital.Atlas/Extensions/NameValueCollectionExtensions.cs
+++ b/src/DeloitteDigital.Atlas/Extensions/NameValueCollectionExtensions.cs
@@ -90,10 +90,10 @@ namespace DeloitteDigital.Atlas.Extensions
         {
             bool value;
             var stringValue = nvc[key];
-            if (Boolean.TryParse(stringValue, out value))
+            if (bool.TryParse(stringValue, out value))
                 return value;
 
-            if (String.IsNullOrEmpty(stringValue))
+            if (string.IsNullOrEmpty(stringValue))
                 return null;
 
             stringValue = stringValue.ToLowerInvariant();

--- a/src/DeloitteDigital.Atlas/Extensions/SiteContextExtensions.cs
+++ b/src/DeloitteDigital.Atlas/Extensions/SiteContextExtensions.cs
@@ -2,7 +2,6 @@
 using Sitecore;
 using Sitecore.Data.Items;
 using Sitecore.Sites;
-using Constants = DD.Atlas.Constants;
 
 namespace DeloitteDigital.Atlas.Extensions
 {

--- a/src/DeloitteDigital.Atlas/Extensions/UrlExtensions.cs
+++ b/src/DeloitteDigital.Atlas/Extensions/UrlExtensions.cs
@@ -74,7 +74,7 @@ namespace DeloitteDigital.Atlas.Extensions
                 return uri.GetPathWithoutQuery();
             }
 
-            return String.Empty;
+            return string.Empty;
         }
 
         /// <summary>
@@ -97,28 +97,28 @@ namespace DeloitteDigital.Atlas.Extensions
         /// <param name="delimiter">The String to delimit the key/value pairs</param>
         /// <param name="omitEmpty"></param>
         /// <returns>A key/value structured query string, delimited by the specified String</returns>
-        public static string ToQueryString(this NameValueCollection parameters, String delimiter, Boolean omitEmpty)
+        public static string ToQueryString(this NameValueCollection parameters, string delimiter, bool omitEmpty)
         {
-            if (String.IsNullOrEmpty(delimiter))
+            if (string.IsNullOrEmpty(delimiter))
                 delimiter = "&";
 
             const char equals = '=';
             if (parameters != null && parameters.Count > 0)
             {
-                var items = new List<String>();
+                var items = new List<string>();
                 for (int i = 0; i < parameters.Count; i++)
                 {
-                    foreach (String value in parameters.GetValues(i))
+                    foreach (string value in parameters.GetValues(i))
                     {
-                        Boolean addValue = !(omitEmpty) || !String.IsNullOrEmpty(value);
+                        bool addValue = !(omitEmpty) || !string.IsNullOrEmpty(value);
                         if (addValue)
-                            items.Add(String.Concat(parameters.GetKey(i), equals, HttpUtility.UrlEncode(value)));
+                            items.Add(string.Concat(parameters.GetKey(i), equals, HttpUtility.UrlEncode(value)));
                     }
                 }
-                return String.Join(delimiter, items.ToArray());
+                return string.Join(delimiter, items.ToArray());
             }
 
-            return String.Empty;
+            return string.Empty;
         }
     }
 }

--- a/src/DeloitteDigital.Atlas/FieldRendering/EmptyRenderingString.cs
+++ b/src/DeloitteDigital.Atlas/FieldRendering/EmptyRenderingString.cs
@@ -7,7 +7,7 @@ namespace DeloitteDigital.Atlas.FieldRendering
     /// </summary>
     public class EmptyRenderingString : IFieldRenderingString
     {
-        private string emptyStringValue = String.Empty;
+        private string emptyStringValue = string.Empty;
 
         public EmptyRenderingString() { }
 

--- a/src/DeloitteDigital.Atlas/FieldRendering/MediaRenderingString.cs
+++ b/src/DeloitteDigital.Atlas/FieldRendering/MediaRenderingString.cs
@@ -38,7 +38,7 @@ namespace DeloitteDigital.Atlas.FieldRendering
             }
             else
             {
-                return String.Empty;
+                return string.Empty;
             }
         }
 

--- a/src/DeloitteDigital.Atlas/Mvc/AdvancedModelLocator.cs
+++ b/src/DeloitteDigital.Atlas/Mvc/AdvancedModelLocator.cs
@@ -40,7 +40,7 @@ namespace DeloitteDigital.Atlas.Mvc
                 }
 
                 throw new InvalidOperationException(
-                    String.Format("Could not locate type '{0}'. Model reference: '{1}'", 
+                    string.Format("Could not locate type '{0}'. Model reference: '{1}'", 
                         (object)typeName, (object)model));
             }
 
@@ -53,7 +53,7 @@ namespace DeloitteDigital.Atlas.Mvc
             }
 
             throw new InvalidOperationException(
-                String.Format("Could not create a model object of type '{0}'. Model reference: '{1}'", 
+                string.Format("Could not create a model object of type '{0}'. Model reference: '{1}'", 
                     (object)typeName, (object)model));
         }
     }

--- a/src/DeloitteDigital.Atlas/Mvc/ControllerFactory.cs
+++ b/src/DeloitteDigital.Atlas/Mvc/ControllerFactory.cs
@@ -24,13 +24,13 @@ namespace DeloitteDigital.Atlas.Mvc
 
             // Controller not found
             if (controllerType == null)
-                throw new HttpException(404, String.Format(
+                throw new HttpException(404, string.Format(
                     "The controller for path '{0}' could not be found or it does not implement IController.",
                     reqContext.HttpContext.Request.Path));
 
             // Controller type does not implement IController interface
             if (!typeof(IController).IsAssignableFrom(controllerType))
-                throw new ArgumentException(String.Format(
+                throw new ArgumentException(string.Format(
                     "Type requested is not a controller: {0}", controllerType.Name),
                     "controllerType");
             try
@@ -40,7 +40,7 @@ namespace DeloitteDigital.Atlas.Mvc
             }
             catch (Exception ex)
             {
-                throw new InvalidOperationException(String.Format(
+                throw new InvalidOperationException(string.Format(
                     "Error resolving controller {0}", controllerType.Name), ex);
             }
 

--- a/src/DeloitteDigital.Atlas/Mvc/RenderingModel.cs
+++ b/src/DeloitteDigital.Atlas/Mvc/RenderingModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using DD.Atlas;
 using DeloitteDigital.Atlas.Caching;
 using DeloitteDigital.Atlas.FieldRendering;
 using DeloitteDigital.Atlas.Logging;
@@ -24,7 +23,7 @@ namespace DeloitteDigital.Atlas.Mvc
         {
             get
             {
-                return String.Format("{0}{1}",
+                return string.Format("{0}{1}",
                     this.Rendering.RenderingItem.Name.Replace(" ", "_"),
                     this.Rendering.UniqueId.ToString().Substring(0, 6));
             }


### PR DESCRIPTION
Change namespace from DD.Atlas to DeloitteDigital.Atlas - note that the MappingMetaData.CacheKeys constant has not been updated

Apply convention of "string.\*" in place of "String.\*", e.g. "string.Format"