### PR TITLE
Created Url() method to allow media url options to be specified

### DIFF
--- a/src/DeloitteDigital.Atlas/FieldRendering/EmptyMediaRenderingString.cs
+++ b/src/DeloitteDigital.Atlas/FieldRendering/EmptyMediaRenderingString.cs
@@ -1,4 +1,6 @@
-﻿using Sitecore.Data.Items;
+﻿using System;
+using Sitecore.Data.Items;
+using Sitecore.Resources.Media;
 
 namespace DeloitteDigital.Atlas.FieldRendering
 {
@@ -7,7 +9,18 @@ namespace DeloitteDigital.Atlas.FieldRendering
     /// </summary>
     public class EmptyMediaRenderingString : IMediaRenderingString
     {
+        [Obsolete("This method is obsolete. Please use Url() or Url(MediaOptions) instead")]
         public string UrlOnly()
+        {
+            return string.Empty;
+        }
+
+        public string Url()
+        {
+            return string.Empty;
+        }
+
+        public string Url(MediaUrlOptions mediaUrlOptions)
         {
             return string.Empty;
         }

--- a/src/DeloitteDigital.Atlas/FieldRendering/IMediaRenderingString.cs
+++ b/src/DeloitteDigital.Atlas/FieldRendering/IMediaRenderingString.cs
@@ -1,4 +1,5 @@
 ﻿using Sitecore.Data.Items;
+using Sitecore.Resources.Media;
 
 namespace DeloitteDigital.Atlas.FieldRendering
 {
@@ -12,6 +13,18 @@ namespace DeloitteDigital.Atlas.FieldRendering
         /// </summary>
         /// <returns>The field's media url</returns>
         string UrlOnly();
+
+        /// <summary>
+        /// Instructs the renderer to render the medial URL with default options
+        /// </summary>
+        /// <returns>The field's media URL</returns>
+        string Url();
+
+        /// <summary>
+        /// Instructs the renderer to render the medial URL with specified url options
+        /// </summary>
+        /// <returns>The field's media URL</returns>
+        string Url(MediaUrlOptions mediaUrlOptions);
 
         /// <summary>
         /// Scales the image size by a specified percentage

--- a/src/DeloitteDigital.Atlas/FieldRendering/MediaRenderingString.cs
+++ b/src/DeloitteDigital.Atlas/FieldRendering/MediaRenderingString.cs
@@ -20,20 +20,35 @@ namespace DeloitteDigital.Atlas.FieldRendering
         }
 
         /// <summary>
-        /// Instructs the renderer to render the media URL only, not the image control or page editor control
+        /// Instructs the renderer to render the media URL only, not the image control or page editor control.
+        /// This method will not respect the .ashx setting in the Sitecore configuration
         /// </summary>
         /// <returns>The field's media url</returns>
+        [Obsolete("This method is obsolete. Please use Url() or Url(MediaOptions) instead")]
         public string UrlOnly()
         {
-            var imageField = (Sitecore.Data.Fields.ImageField)this.Item.Fields[this.FieldName];
+            return Url(MediaUrlOptions.GetShellOptions());
+        }
 
-            if (imageField != null && imageField.MediaItem != null)
+        /// <summary>
+        /// Instructs the render to render the media URL only using the default Sitecore Media URL rendering options
+        /// </summary>
+        public string Url()
+        {
+            return Url(new MediaUrlOptions());
+        }
+
+        /// <summary>
+        /// Instructs the render to render the media URL only using the provided media url options
+        /// </summary>
+        public string Url(MediaUrlOptions mediaUrlOptions)
+        {
+            var imageField = (Sitecore.Data.Fields.ImageField)Item.Fields[FieldName];
+
+            if (imageField?.MediaItem != null)
             {
-                // TODO: add support for more media option attributes, for UrlOnly rendering                
-                ////var mediaUrlOptions = MediaUrlOptions.GetThumbnailOptions(imageField.MediaItem);
-                var mediaUrlOptions = MediaUrlOptions.GetShellOptions();
-                mediaUrlOptions.Width = this.Attributes.ContainsKey("width") ? (int)this.Attributes["width"] : mediaUrlOptions.Width;
-                mediaUrlOptions.Height = this.Attributes.ContainsKey("height") ? (int)this.Attributes["height"] : mediaUrlOptions.Height;
+                mediaUrlOptions.Width = Attributes.ContainsKey("width") ? (int)Attributes["width"] : mediaUrlOptions.Width;
+                mediaUrlOptions.Height = Attributes.ContainsKey("height") ? (int)Attributes["height"] : mediaUrlOptions.Height;
                 return MediaManager.GetMediaUrl(imageField.MediaItem, mediaUrlOptions);
             }
             else


### PR DESCRIPTION
Created Url() method for IMediaRenderingString that takes media options as a paramater or if none specified default to the rendering options from the Sitecore configuration.

Marked UrlOnly() method as obsolete in favour for Url() method.